### PR TITLE
remove deprecated scanOnPush config

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ async function run () {
     }
 
     console.log('Repository does not exist. Creating...')
-    await ecr.createRepository({ repositoryName, imageScanningConfiguration: { scanOnPush: true } }).promise()
+    await ecr.createRepository({ repositoryName }).promise()
 
     const accessPolicyText = JSON.stringify({
       Version: '2008-10-17',


### PR DESCRIPTION
Per repo `scanOnPush` is deprecated.
Scan configuration should be configured on a registry level.